### PR TITLE
Update setup.py for later python version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,13 @@
 # Copyright (C) 2021 NVIDIA Corporation
 # Licensed under the GNU General Public License v3.0 [see LICENSE for details]
 
-from setuptools import setup
+from setuptools import find_packages, setup
 
 setup(
     name='dex-ycb-toolkit',
     version='1.0',
+    packages=find_packages(),
+    include_package_data=True,
     install_requires=[
         'chumpy',
         'numpy',

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@ setup(
     name='dex-ycb-toolkit',
     version='1.0',
     packages=find_packages(),
-    include_package_data=True,
     install_requires=[
         'chumpy',
         'numpy',


### PR DESCRIPTION
Current install hangs on at least 3.7.13, unsure about older versions of 3.7
Update allows for successful install up to latest (3.10.x)